### PR TITLE
Fix list calculated_tables

### DIFF
--- a/src/stride/project.py
+++ b/src/stride/project.py
@@ -1,12 +1,12 @@
-from collections import defaultdict
 import os
 import shutil
 import subprocess
+from collections import defaultdict
 from pathlib import Path
 from typing import Any, Self
 
-from chronify.exceptions import InvalidParameter, InvalidOperation
 import duckdb
+from chronify.exceptions import InvalidOperation, InvalidParameter
 from chronify.utils.path_utils import check_overwrite
 from dsgrid.utils.files import dump_json_file
 from duckdb import DuckDBPyConnection, DuckDBPyRelation

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import re
 
 import pandas as pd
 import pytest
@@ -103,7 +102,7 @@ def test_override_calculated_table(
     cmd = ["calculated-tables", "list", str(new_path)]
     result = runner.invoke(cli, cmd)
     assert result.exit_code == 0
-    assert "true" not in result.stdout
+    assert "energy_projection_res_load_shapes_override" not in result.stdout
 
     df = pd.read_parquet(data_file)
     df["value"] *= 3
@@ -138,12 +137,7 @@ def test_override_calculated_table(
     cmd = ["calculated-tables", "list", str(project2.path)]
     result = runner.invoke(cli, cmd)
     assert result.exit_code == 0
-    found = False
-    regex = re.compile(r"energy_projection_res_load_shapes.*true")
-    for line in result.stdout.splitlines():
-        if regex.search(line) is not None:
-            found = True
-    assert found
+    assert "energy_projection_res_load_shapes_override" in result.stdout
 
     # Try to override an override table, which isn't allowed.
     data_file = tmp_path / "data.parquet"


### PR DESCRIPTION
Display the calculated tables and overrides in a simpler way. Here is an example:

```
$ stride calculated-tables list test_project
```
```
Calculated tables for all scenarios:
  energy_intensity_com_ind_tra
  energy_intensity_com_ind_tra_gdp
  energy_intensity_com_ind_tra_gdp_applied_regression
  energy_intensity_com_ind_tra_pivoted
  energy_intensity_parsed
  energy_intensity_res
  energy_intensity_res_hdi
  energy_intensity_res_hdi_population
  energy_intensity_res_hdi_population_applied_regression
  energy_intensity_res_pivoted
  energy_projection
  energy_projection_com_ind_tra_load_shapes
  energy_projection_res_load_shapes
  gdp_country
  hdi_country
  load_shapes_com_ind_tra
  load_shapes_res
  population_country

Override tables by scenario:
  Scenario: baseline
    None

  Scenario: alternate_gdp
    energy_projection_res_load_shapes_override
```