### PR TITLE
Bump dsgrid version to v0.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "dash-bootstrap-components>=2.0.3",
     "dbt-core >= 1.10.5, < 2",
     "dbt-duckdb",
-    "dsgrid-toolkit >= 0.3.0, < 0.4.0",
+    "dsgrid-toolkit >= 0.3.3, < 0.4.0",
     "duckdb >= 1.1, < 2",
     "loguru",
     "pandas>=2.2,<3",


### PR DESCRIPTION
This fixes an issue that prevented linux/arm64 builds from using pre-built dsgrid wheels.